### PR TITLE
Apply modern glassmorphism style

### DIFF
--- a/src/assets/css/glassmorphism.css
+++ b/src/assets/css/glassmorphism.css
@@ -1,0 +1,40 @@
+.glass {
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    background: var(--glass-bg-dark);
+    border-radius: var(--glass-border-radius);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+}
+
+.glass-light {
+    background: var(--glass-bg-light);
+}
+
+.glass-button {
+    border: 1px solid rgba(var(--element-color-rgb), 0.4);
+    background: rgba(var(--element-color-rgb), 0.2);
+    color: var(--color);
+    padding: 0.4rem 1rem;
+    border-radius: var(--glass-border-radius);
+    cursor: pointer;
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    transition: var(--transition);
+}
+
+.glass-button:hover {
+    background: rgba(var(--element-color-rgb), 0.3);
+    transform: translateY(-2px);
+}
+
+.glass-panel {
+    padding: 2rem;
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    background: var(--glass-bg-dark);
+    border-radius: var(--glass-border-radius);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+}

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -1,15 +1,28 @@
 @import "font.css";
 @import 'theme.css';
+@import 'glassmorphism.css';
 
 body {
-    background-color: var(--background);
+    margin: 0;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--color);
     font-family: "Poppins";
     letter-spacing: 0px;
+    background: var(--background-gradient);
+    background-attachment: fixed;
 }
 
 img {
     -webkit-user-drag: none;
     user-select: none;
+}
+
+#splash {
+    display: none;
+    position: relative;
 }
 
 .splash {

--- a/src/assets/css/launcher.css
+++ b/src/assets/css/launcher.css
@@ -13,6 +13,7 @@ body {
     color: var(--color);
     font-family: 'Poppins';
     font-weight: bolder;
+    background: var(--background-gradient);
     background-size: cover;
     background-position: center;
     background-attachment: fixed;

--- a/src/assets/css/theme.css
+++ b/src/assets/css/theme.css
@@ -11,6 +11,7 @@
     --glass-border: 1px solid rgba(255, 255, 255, 0.18);
     --glass-bg-dark: rgba(29, 29, 29, 0.25);
     --glass-bg-light: rgba(255, 255, 255, 0.15);
+    --background-gradient: linear-gradient(135deg, #1a1a1a 0%, #323232 100%);
 }
 
 .dark {
@@ -25,6 +26,7 @@
     --glass-text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
     --glass-highlight: rgba(255, 255, 255, 0.05);
     --glass-border-color: rgba(255, 255, 255, 0.1);
+    --background-gradient: linear-gradient(135deg, #1a1a1a 0%, #323232 100%);
 }
 
 .light {
@@ -39,4 +41,5 @@
     --glass-text-shadow: 0 1px 1px rgba(255, 255, 255, 0.15);
     --glass-highlight: rgba(255, 255, 255, 0.25);
     --glass-border-color: rgba(255, 255, 255, 0.3);
+    --background-gradient: linear-gradient(135deg, #ffffff 0%, #d9d9d9 100%);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="assets/css/index.css">
     </head>
     <body>
-        <div id="splash" style="display:none">
+        <div id="splash" class="glass-panel" style="display:none">
             <img class="splash" src="assets/images/icon.png" />
             <p class="splash-message"></p>
             <p class="splash-author"><span class="author"></span></p>


### PR DESCRIPTION
## Summary
- implement common glassmorphism helpers
- add gradient backgrounds for dark and light themes
- style splash screen container with glass effect
- use gradient backgrounds in launcher and index

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848aabce27c8332b7fa440b52cfebef