### PR TITLE
Revamp launcher UI with glassmorphism

### DIFF
--- a/src/assets/css/glassmorphism.css
+++ b/src/assets/css/glassmorphism.css
@@ -1,0 +1,35 @@
+.glass {
+    background: var(--glass-bg-dark);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-radius: var(--glass-border-radius);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+}
+
+.glass-button {
+    background: rgba(var(--element-color-rgb), 0.2);
+    color: var(--color);
+    border: 1px solid rgba(var(--element-color-rgb), 0.4);
+    border-radius: var(--glass-border-radius);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.glass-button:hover {
+    background: rgba(var(--element-color-rgb), 0.3);
+    box-shadow: 0 6px 25px rgba(0, 0, 0, 0.3);
+}
+
+.glass-container {
+    backdrop-filter: blur(30px);
+    -webkit-backdrop-filter: blur(30px);
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--glass-border-radius);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    padding: 1rem;
+}

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -1,5 +1,6 @@
 @import "font.css";
 @import 'theme.css';
+@import 'glassmorphism.css';
 
 body {
     background-color: var(--background);
@@ -12,14 +13,19 @@ img {
     user-select: none;
 }
 
-.splash {
+#splash {
     position: absolute;
-    top: 180px;
+    top: 50%;
     left: 50%;
-    transform: translate(-50%);
+    transform: translate(-50%, -50%);
+    text-align: center;
+}
+
+.splash {
     width: 140px;
     height: 140px;
-    transition: opacity .3s, top 1.5s;
+    margin: 0 auto;
+    transition: opacity 0.3s, transform 1.5s;
     opacity: 0;
 }
 
@@ -28,14 +34,12 @@ img {
 }
 
 .splash.translate {
-    top: 129px;
+    transform: translateY(-50px);
 }
 
 .splash-message {
-    position: absolute;
-    top: 289px;
-    left: 0px;
-    width: 400px;
+    margin-top: 1rem;
+    width: 100%;
     font: normal normal bold 19px/29px Poppins;
     text-align: center;
     letter-spacing: 0px;
@@ -49,10 +53,8 @@ img {
 }
 
 .splash-author {
-    position: absolute;
-    top: 326px;
-    left: 0px;
-    width: 400px;
+    margin-top: 0.5rem;
+    width: 100%;
     text-align: center;
     transition: opacity 1.5s;
     font: normal normal normal 9px/13px Poppins;
@@ -69,10 +71,8 @@ img {
 }
 
 .message {
-    position: absolute;
-    top: 347px;
-    left: 0px;
-    width: 400px;
+    margin-top: 1rem;
+    width: 100%;
     text-align: center;
     transition: opacity 1.5s;
     font: normal normal bold 18px/27px Poppins;
@@ -81,8 +81,7 @@ img {
 }
 
 .download-update {
-    position: absolute;
-    left: 25%;
+    position: relative;
     margin-top: 20px;
     width: 200px;
     font: normal normal bold 22px / 45px Poppins;
@@ -103,11 +102,10 @@ img {
 }
 
 .progress {
-    position: absolute;
-    top: 410px;
-    left: 106px;
-    width: 189px;
+    position: relative;
+    width: 60%;
     height: 10px;
+    margin: 1rem auto;
     appearance: none;
     transition: opacity .2s;
     opacity: 0;

--- a/src/assets/css/launcher.css
+++ b/src/assets/css/launcher.css
@@ -6,6 +6,19 @@
 @import 'panels/home.css';
 @import 'panels/settings.css';
 
+.launcher-container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90%;
+    height: 90%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/src/assets/css/theme.css
+++ b/src/assets/css/theme.css
@@ -1,6 +1,6 @@
 .global {
-    --element-color: #00bd7a;
-    --element-color-rgb: 0, 189, 122; /* Ajout de la valeur RGB pour les effets de transparence */
+    --element-color: #9b59b6;
+    --element-color-rgb: 155, 89, 182; /* RGB value used for transparency effects */
     --transition: all 0.5s cubic-bezier(1, 0.46, 0, 1.29);
     --dark-color: #292929;
     --light-color: rgb(245, 245, 245);

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="assets/css/index.css">
     </head>
     <body>
-        <div id="splash" style="display:none">
+        <div id="splash" class="glass-container" style="display:none">
             <img class="splash" src="assets/images/icon.png" />
             <p class="splash-message"></p>
             <p class="splash-author"><span class="author"></span></p>

--- a/src/launcher.html
+++ b/src/launcher.html
@@ -5,6 +5,7 @@
         <link rel="stylesheet" href="assets/css/launcher.css">
     </head>
     <body>
+        <div class="launcher-container glass-container">
         <div class="dragbar"></div>
         <div class="darwin">
             <div class="frame glass">
@@ -36,7 +37,7 @@
                 </div>
             </div>
         </div>
-
+        </div>
         <script src="assets/js/launcher.js" type="module"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- switch primary color to purple
- implement glassmorphism utility styles
- center splash screen using glass container
- wrap launcher body in glass container
- add layout helper for launcher container

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848ad37e6a483329c4a955732f22f46